### PR TITLE
Remove typings for any-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typings": "^1.3.2"
   },
   "dependencies": {
-    "any-promise": "^1.1.0",
+    "any-promise": "^1.3.0",
     "xtend": "^4.0.1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -7,7 +7,6 @@
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#1c56e368e17bb28ca57577250624ca5bd561aa81"
   },
   "dependencies": {
-    "any-promise": "github:typings/typed-any-promise#74ba6cf22149ff4de39c2338a9cb84f9ded6f042",
     "xtend": "registry:npm/xtend#4.0.0+20160211003958"
   }
 }


### PR DESCRIPTION
Update `any-promise` version,

`any-promise@1.3.0` contains typings itself already. 🌷 

I'm touching this as I look for a repo that I can use for `jspm:` testing. :smirk: